### PR TITLE
Added Tanstack Query

### DIFF
--- a/app/api/trending/route.ts
+++ b/app/api/trending/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+    const key = process.env.TMDB_API_KEY;
+
+    if (!key) {
+        return NextResponse.json(
+            { error: "Missing TMDB API key" },
+            { status: 500 }
+        );
+    }
+
+    try {
+        const res = await fetch(
+            `https://api.themoviedb.org/3/trending/movie/week?api_key=${key}&language=en-US`
+        );
+
+        if (!res.ok) {
+            return NextResponse.json(
+                { error: `TMDB error ${res.status}` },
+                { status: res.status }
+            );
+        }
+        
+        const data = await res.json();
+        return NextResponse.json(data);
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+};

--- a/app/api/upcoming/route.ts
+++ b/app/api/upcoming/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+    const key = process.env.TMDB_API_KEY;
+
+    if (!key) {
+        return NextResponse.json(
+            { error: "Missing TMDB API key" },
+            { status: 500 }
+        );
+    }
+
+    try {
+        const res = await fetch(
+            `https://api.themoviedb.org/3/movie/upcoming?api_key=${key}&language=en-US`
+        );
+
+        if (!res.ok) {
+            return NextResponse.json(
+                { error: `TMDB error ${res.status}` },
+                { status: res.status }
+            );
+        }
+        
+        const data = await res.json();
+        return NextResponse.json(data);
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return NextResponse.json({ error: message }, { status: 500 });
+    }
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { Providers } from "./providers";
 import VideoPlayer from "../components/videoPlayer/VideoPlayer";
 import TrendingMovies from "../components/movies/trending/trendingMovies";
 import UpcomingMovies from "../components/movies/upcoming/upcomingMovies";
@@ -6,14 +7,16 @@ const Page = async () => {
 
     return (
         <>
-            <div className="flex flex-col max-w-[1440px] mx-auto bg-gray-100 text-gray-600 dark:bg-primary-dark dark:text-gray-200 p-4">
-                <div className="w-full mb-4">
-                    <TrendingMovies />
+            <Providers>
+                <div className="flex flex-col max-w-[1440px] mx-auto bg-gray-100 text-gray-600 dark:bg-primary-dark dark:text-gray-200 p-4">
+                    <div className="w-full mb-4">
+                        <TrendingMovies />
+                    </div>
+                    
+                    <UpcomingMovies />
+                    <VideoPlayer />
                 </div>
-                
-                <UpcomingMovies />
-                <VideoPlayer />
-            </div>
+            </Providers>
         </>
     );
 };

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+export const Providers = ({ children }) => {
+    const [queryClient] = useState(() => new QueryClient());
+
+    return (
+        <QueryClientProvider client={queryClient}>
+            {children}
+            <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
+    );
+};

--- a/components/movies/trending/trendingMovies.tsx
+++ b/components/movies/trending/trendingMovies.tsx
@@ -1,21 +1,28 @@
+'use client';
+
+import { useQuery } from "@tanstack/react-query";
 import TrendingShell from "./trendingShell";
+import { CACHE_DURATION } from "../../../constants/global";
 
-const TrendingMovies = async () => {
-    const tmdbApiKey = process.env.TMDB_API_KEY;
-    const response = await fetch(`https://api.themoviedb.org/3/trending/movie/week?api_key=${tmdbApiKey}&language=en-US`);
+const TrendingMovies = () => {
+    const { data, error, isLoading } = useQuery({
+        queryKey: ["trendingMovies"],
+        queryFn: async () => {
+            const res = await fetch("/api/trending");
+            if (!res.ok) {
+                throw new Error("Failed to fetch trending movies");
+            }
+            return res.json();
+        },
+        staleTime: CACHE_DURATION
+    });
 
-    if (!tmdbApiKey) {
-        throw new Error("TMDB_API_KEY is not defined");
-    }
-    if (!response.ok) {
-        throw new Error("Failed to fetch trending videos");
-    }
-
-    const trending = await response.json();
+    if (isLoading) return <p>Loading trending...</p>;
+    if (error) return <p>Error: {error.message}</p>;
 
     return (
         <>
-            <TrendingShell trending={trending.results} />   
+            <TrendingShell trending={data.results} />
         </>
     );
 };

--- a/components/movies/upcoming/upcomingMovies.tsx
+++ b/components/movies/upcoming/upcomingMovies.tsx
@@ -1,26 +1,31 @@
-import Image from 'next/image';
-import type { MovieType } from '../../../types/global';
+'use client';
 
-const PopularMovies = async () => {
-    const tmdbApiKey = process.env.TMDB_API_KEY;
-    const response = await fetch(`https://api.themoviedb.org/3/movie/upcoming?api_key=${tmdbApiKey}&language=en-US`, {
-        next: { revalidate: 60 },
+import { useQuery } from "@tanstack/react-query";
+import Image from "next/image";
+import type { MovieType } from "../../../types/global";
+import { CACHE_DURATION } from "../../../constants/global";
+
+const UpcomingMovies = () => {
+    const { data, error, isLoading } = useQuery({
+        queryKey: ["trendingMovies"],
+        queryFn: async () => {
+            const res = await fetch("/api/upcoming");
+            if (!res.ok) {
+                throw new Error("Failed to fetch trending movies");
+            }
+            return res.json();
+        },
+        staleTime: CACHE_DURATION
     });
 
-    if (!tmdbApiKey) {
-        throw new Error("TMDB_API_KEY is not defined");
-    }
-    if (!response.ok) {
-        throw new Error("Failed to fetch trending videos");
-    }
-
-    const upcoming = await response.json();
+    if (isLoading) return <p>Loading trending...</p>;
+    if (error) return <p>Error: {error.message}</p>;
 
     return (
         <>
             <div className="flex flex-col w-full">
                 <h1 className="text-2xl font-bold mb-4">Upcoming Movies</h1>
-                {upcoming.results.map((movie: MovieType) => (
+                {data.results.map((movie: MovieType) => (
                     <div key={movie.id} className="p-4">
                         <Image
                             src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
@@ -29,8 +34,7 @@ const PopularMovies = async () => {
                             height={500}
                             className="rounded-lg shadow-lg"
                             loading="lazy"
-                            style={{ width: '200px', height: 'auto' }}
-
+                            style={{ width: "200px", height: "auto" }}
                         />
                         <h2 className="text-xl font-bold">{movie.title}</h2>
                         <p className="text-sm">{movie.release_date}</p>
@@ -42,4 +46,4 @@ const PopularMovies = async () => {
     );
 };
 
-export default PopularMovies;
+export default UpcomingMovies;

--- a/constants/global.ts
+++ b/constants/global.ts
@@ -1,0 +1,1 @@
+export const CACHE_DURATION = 1000 * 60 * 30; // 30 minutes

--- a/lib/api/api.tsx
+++ b/lib/api/api.tsx
@@ -1,0 +1,8 @@
+const tmdbApiKey = process.env.TMDB_API_KEY;
+
+export const fetchTrendingMovies = async () => {
+    const response = await fetch(
+        `https://api.themoviedb.org/3/trending/movie/week?api_key=${tmdbApiKey}&language=en-US`
+    );
+    return response.json();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "chads-nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.85.3",
+        "@tanstack/react-query-devtools": "^5.85.3",
         "bootstrap-icons": "^1.13.1",
         "next": "^15.4.6",
         "react": "^19.0.0",
@@ -1291,6 +1293,59 @@
         "@tailwindcss/oxide": "4.1.10",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.3.tgz",
+      "integrity": "sha512-9Ne4USX83nHmRuEYs78LW+3lFEEO2hBDHu7mrdIgAFx5Zcrs7ker3n/i8p4kf6OgKExmaDN5oR0efRD7i2J0DQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.84.0.tgz",
+      "integrity": "sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.3.tgz",
+      "integrity": "sha512-AqU8TvNh5GVIE8I+TUU0noryBRy7gOY0XhSayVXmOPll4UkZeLWKDwi0rtWOZbwLRCbyxorfJ5DIjDqE7GXpcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.85.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.85.3.tgz",
+      "integrity": "sha512-WSVweCE1Kh1BVvPDHAmLgGT+GGTJQ9+a7bVqzD+zUiUTht+salJjYm5nikpMNaHFPJV102TCYdvgHgBXtURRNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.84.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.85.3",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.3",
+    "@tanstack/react-query-devtools": "^5.85.3",
     "bootstrap-icons": "^1.13.1",
     "next": "^15.4.6",
     "react": "^19.0.0",


### PR DESCRIPTION
* Installed tanstack query
* implemented a pattern that works excellent with NextJS app router (app/api/trending)
* created constants directory added CACHE_DURATION to global constants

Note: currently for development purposes I have the cache duration set to 30 minutes. No need to continually ping the endpoint when we're just doing local development currently. This duration can be adjusted for all request in the global constants file.